### PR TITLE
Adjustments for pyscope on real hardware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ dmypy.json
 *OmniSim*
 !coverage.xml
 docs/source/api/auto_api/
+pgHardware

--- a/pyscope/observatory/ascom_camera.py
+++ b/pyscope/observatory/ascom_camera.py
@@ -1,7 +1,7 @@
 import logging
-from datetime import datetime as dt
 
 import numpy as np
+from astropy.time import Time
 
 from .ascom_device import ASCOMDevice
 from .camera import Camera
@@ -65,7 +65,7 @@ class ASCOMCamera(ASCOMDevice, Camera):
     def StartExposure(self, Duration, Light):
         logger.debug(f"ASCOMCamera.StartExposure({Duration}, {Light}) called")
         self._last_exposure_duration = Duration
-        self._last_exposure_start_time = str(dt.utcnow())
+        self._last_exposure_start_time = str(Time.now())
         self._device.StartExposure(Duration, Light)
 
     def StopExposure(self):

--- a/pyscope/observatory/ascom_camera.py
+++ b/pyscope/observatory/ascom_camera.py
@@ -239,13 +239,17 @@ class ASCOMCamera(ASCOMDevice, Camera):
     def LastExposureStartTime(self):
         logger.debug(f"ASCOMCamera.LastExposureStartTime property called")
         last_time = self._device.LastExposureStartTime
-        return last_time if last_time != '' and last_time != None else self._last_exposure_start_time
-    
+        return (
+            last_time
+            if last_time != "" and last_time != None
+            else self._last_exposure_start_time
+        )
+
     @property
     def LastInputExposureDuration(self):
         logger.debug(f"ASCOMCamera.LastInputExposureDuration property called")
         return self._last_exposure_duration
-    
+
     @LastInputExposureDuration.setter
     def LastInputExposureDuration(self, value):
         logger.debug(f"ASCOMCamera.LastInputExposureDuration property set to {value}")

--- a/pyscope/observatory/ascom_camera.py
+++ b/pyscope/observatory/ascom_camera.py
@@ -22,6 +22,7 @@ class ASCOMCamera(ASCOMDevice, Camera):
         self._last_exposure_start_time = None
         self._image_data_type = None
         self._DoTranspose = True
+        self._camera_time = True
 
     def AbortExposure(self):
         logger.debug(f"ASCOMCamera.AbortExposure() called")
@@ -123,6 +124,11 @@ class ASCOMCamera(ASCOMDevice, Camera):
     def CameraYSize(self):
         logger.debug(f"ASCOMCamera.CameraYSize property called")
         return self._device.CameraYSize
+
+    @property
+    def CameraTime(self):
+        logger.debug(f"ASCOMCamera.CameraTime property called")
+        return self._camera_time
 
     @property
     def CanAbortExposure(self):
@@ -274,7 +280,11 @@ class ASCOMCamera(ASCOMDevice, Camera):
     @property
     def LastExposureDuration(self):
         logger.debug(f"ASCOMCamera.LastExposureDuration property called")
-        return self._device.LastExposureDuration
+        last_exposure_duration = self._device.LastExposureDuration
+        if last_exposure_duration is None or last_exposure_duration == 0:
+            last_exposure_duration = self.LastInputExposureDuration
+            self._camera_time = False
+        return last_exposure_duration
 
     @property
     def LastExposureStartTime(self):

--- a/pyscope/observatory/ascom_camera.py
+++ b/pyscope/observatory/ascom_camera.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime as dt
 
 from .ascom_device import ASCOMDevice
 from .camera import Camera
@@ -15,7 +16,8 @@ class ASCOMCamera(ASCOMDevice, Camera):
             device_number=device_number,
             protocol=protocol,
         )
-        self._LastInputExposureDuration = None
+        self._last_exposure_duration = None
+        self._last_exposure_start_time = None
 
     def AbortExposure(self):
         logger.debug(f"ASCOMCamera.AbortExposure() called")
@@ -27,7 +29,8 @@ class ASCOMCamera(ASCOMDevice, Camera):
 
     def StartExposure(self, Duration, Light):
         logger.debug(f"ASCOMCamera.StartExposure({Duration}, {Light}) called")
-        self.LastInputExposureDuration = Duration
+        self._last_exposure_duration = Duration
+        self._last_exposure_start_time = str(dt.utcnow())
         self._device.StartExposure(Duration, Light)
 
     def StopExposure(self):
@@ -235,17 +238,18 @@ class ASCOMCamera(ASCOMDevice, Camera):
     @property
     def LastExposureStartTime(self):
         logger.debug(f"ASCOMCamera.LastExposureStartTime property called")
-        return self._device.LastExposureStartTime
+        last_time = self._device.LastExposureStartTime
+        return last_time if last_time != '' and last_time != None else self._last_exposure_start_time
     
     @property
     def LastInputExposureDuration(self):
         logger.debug(f"ASCOMCamera.LastInputExposureDuration property called")
-        return self._LastInputExposureDuration
+        return self._last_exposure_duration
     
     @LastInputExposureDuration.setter
     def LastInputExposureDuration(self, value):
         logger.debug(f"ASCOMCamera.LastInputExposureDuration property set to {value}")
-        self._LastInputExposureDuration = value
+        self._last_exposure_duration = value
 
     @property
     def MaxADU(self):

--- a/pyscope/observatory/ascom_camera.py
+++ b/pyscope/observatory/ascom_camera.py
@@ -15,6 +15,7 @@ class ASCOMCamera(ASCOMDevice, Camera):
             device_number=device_number,
             protocol=protocol,
         )
+        self._LastInputExposureDuration = None
 
     def AbortExposure(self):
         logger.debug(f"ASCOMCamera.AbortExposure() called")
@@ -26,6 +27,7 @@ class ASCOMCamera(ASCOMDevice, Camera):
 
     def StartExposure(self, Duration, Light):
         logger.debug(f"ASCOMCamera.StartExposure({Duration}, {Light}) called")
+        self.LastInputExposureDuration = Duration
         self._device.StartExposure(Duration, Light)
 
     def StopExposure(self):
@@ -234,6 +236,16 @@ class ASCOMCamera(ASCOMDevice, Camera):
     def LastExposureStartTime(self):
         logger.debug(f"ASCOMCamera.LastExposureStartTime property called")
         return self._device.LastExposureStartTime
+    
+    @property
+    def LastInputExposureDuration(self):
+        logger.debug(f"ASCOMCamera.LastInputExposureDuration property called")
+        return self._LastInputExposureDuration
+    
+    @LastInputExposureDuration.setter
+    def LastInputExposureDuration(self, value):
+        logger.debug(f"ASCOMCamera.LastInputExposureDuration property set to {value}")
+        self._LastInputExposureDuration = value
 
     @property
     def MaxADU(self):

--- a/pyscope/observatory/maxim.py
+++ b/pyscope/observatory/maxim.py
@@ -1,8 +1,9 @@
 import logging
 import platform
 import time
-from win32com.client import Dispatch
 from datetime import datetime as dt
+
+from win32com.client import Dispatch
 
 from .autofocus import Autofocus
 from .camera import Camera

--- a/pyscope/observatory/maxim.py
+++ b/pyscope/observatory/maxim.py
@@ -1,6 +1,8 @@
 import logging
 import platform
 import time
+from win32com.client import Dispatch
+from datetime import datetime as dt
 
 from .autofocus import Autofocus
 from .camera import Camera
@@ -124,7 +126,7 @@ class _MaximCamera(Camera):
     def StartExposure(self, Duration, Light):
         logger.debug(f"StartExposure called with Duration={Duration}, Light={Light}")
         self._last_exposure_duration = Duration
-        self._last_exposure_start_time = time.time()
+        self._last_exposure_start_time = str(dt.utcnow())
         self._com_object.Expose(Duration, Light)
 
     def StopExposure(self):

--- a/pyscope/observatory/maxim.py
+++ b/pyscope/observatory/maxim.py
@@ -1,7 +1,8 @@
 import logging
 import platform
 import time
-from datetime import datetime as dt
+
+from astropy.time import Time
 
 from .autofocus import Autofocus
 from .camera import Camera
@@ -125,7 +126,7 @@ class _MaximCamera(Camera):
     def StartExposure(self, Duration, Light):
         logger.debug(f"StartExposure called with Duration={Duration}, Light={Light}")
         self._last_exposure_duration = Duration
-        self._last_exposure_start_time = str(dt.utcnow())
+        self._last_exposure_start_time = str(Time.now())
         self._com_object.Expose(Duration, Light)
 
     def StopExposure(self):

--- a/pyscope/observatory/maxim.py
+++ b/pyscope/observatory/maxim.py
@@ -3,8 +3,6 @@ import platform
 import time
 from datetime import datetime as dt
 
-from win32com.client import Dispatch
-
 from .autofocus import Autofocus
 from .camera import Camera
 from .device import Device

--- a/pyscope/observatory/observatory.py
+++ b/pyscope/observatory/observatory.py
@@ -2417,6 +2417,17 @@ class Observatory:
             self.camera.Connected = True
         except:
             return {"CONNECT": (False, "Camera connection")}
+        
+        # If ASCOM camera, EXPTIME and EXPOSURE should be obtained
+        # from camera.LastExposureDuration
+        if self._camera_driver == "ASCOMCamera":
+            try:
+                last_exposure_duration = self.camera.LastExposureDuration
+            except:
+                last_exposure_duration = self.camera.LastInputExposureDuration
+        else:
+            last_exposure_duration = None
+        
         info = {
             "CAMCON": (True, "Camera connection"),
             "CAMREADY": (self.camera.ImageReady, "Image ready"),
@@ -2431,8 +2442,8 @@ class Observatory:
             "JD": (None, "Julian date"),
             "MJD": (None, "Modified Julian date"),
             "MJD-OBS": (None, "Modified Julian date"),
-            "EXPTIME": (None, "Exposure time [seconds]"),
-            "EXPOSURE": (None, "Exposure time [seconds]"),
+            "EXPTIME": (last_exposure_duration, "Exposure time [seconds]"),
+            "EXPOSURE": (last_exposure_duration, "Exposure time [seconds]"),
             "SUBEXP": (None, "Subexposure time [seconds]"),
             "XBINNING": (self.camera.BinX, "Image binning factor in width"),
             "YBINNING": (self.camera.BinY, "Image binning factor in height"),

--- a/pyscope/observatory/observatory.py
+++ b/pyscope/observatory/observatory.py
@@ -2522,24 +2522,13 @@ class Observatory:
         except:
             pass
         try:
-            # If ASCOM camera, EXPTIME and EXPOSURE should be obtained
-            # from camera.LastExposureDuration (if that property exists or is not 0.0).
-            if self._camera_driver == "ASCOMCamera":
-                try:
-                    last_exposure_duration = self.camera.LastExposureDuration
-                    cam_time = True
-                    if last_exposure_duration == 0:
-                        last_exposure_duration = self.camera.LastInputExposureDuration
-                        cam_time = False
-                except:
-                    last_exposure_duration = self.camera.LastInputExposureDuration
-                    cam_time = False
-            else:
-                last_exposure_duration = None
-                cam_time = False
+            last_exposure_duration = self.camera.LastExposureDuration
             info["EXPTIME"] = (last_exposure_duration, info["EXPTIME"][1])
             info["EXPOSURE"] = (last_exposure_duration, info["EXPOSURE"][1])
-            info["CAMTIME"] = (cam_time, info["CAMTIME"][1])
+        except:
+            pass
+        try:
+            info["CAMTIME"] = (self.camera.CameraTime, info["CAMTIME"][1])
         except:
             pass
         try:

--- a/pyscope/observatory/observatory.py
+++ b/pyscope/observatory/observatory.py
@@ -1168,11 +1168,14 @@ class Observatory:
         if not self.camera.ImageReady:
             logger.exception("Image is not ready, cannot be saved")
             return False
+        
+        # Read out the image array
+        img_array = self.camera.ImageArray
 
         if (
-            self.camera.ImageArray is None
-            or len(self.camera.ImageArray) == 0
-            or len(self.camera.ImageArray[0]) == 0
+            img_array is None
+            or len(img_array) == 0
+            or len(img_array) == 0
         ):
             logger.exception("Image array is empty, cannot be saved")
             return False
@@ -1182,9 +1185,9 @@ class Observatory:
         hdr["SIMPLE"] = True
         hdr["BITPIX"] = (16, "8 unsigned int, 16 & 32 int, -32 & -64 real")
         hdr["NAXIS"] = (2, "number of axes")
-        hdr["NAXIS1"] = (len(self.camera.ImageArray), "fastest changing axis")
+        hdr["NAXIS1"] = (len(img_array), "fastest changing axis")
         hdr["NAXIS2"] = (
-            len(self.camera.ImageArray[0]),
+            len(img_array[0]),
             "next to fastest changing axis",
         )
         hdr["BSCALE"] = (1, "physical=BZERO + BSCALE*array_value")
@@ -1223,13 +1226,6 @@ class Observatory:
                 history = [history]
             for hist in history:
                 hdr["HISTORY"] = hist
-
-        # By default, the ImageArray is 32 bit int, at least on my system
-        # of a ZWO 290MM Mini - we need to convert it to 16 bit unsigned int
-        img_array = np.array(self.camera.ImageArray).astype(np.uint16)
-        # Transpose the image array to match the FITS standard
-        # as well as the axis order defined above
-        img_array = np.transpose(img_array)
 
         hdu = fits.PrimaryHDU(img_array, header=hdr)
         hdu.writeto(filename, overwrite=overwrite)

--- a/pyscope/observatory/observatory.py
+++ b/pyscope/observatory/observatory.py
@@ -2384,7 +2384,9 @@ class Observatory:
 
         # Not sure if this if statement is a good idea here...
         if dictionary.get("rotator_driver", self.rotator_driver) is not None:
-            self.rotator_reverse = dictionary.get("rotator_reverse", self.rotator_reverse)
+            self.rotator_reverse = dictionary.get(
+                "rotator_reverse", self.rotator_reverse
+            )
             self.rotator_min_angle = dictionary.get(
                 "rotator_min_angle", self.rotator_min_angle
             )
@@ -2416,7 +2418,7 @@ class Observatory:
         try:
             self.camera.Connected = True
         except:
-            return {"CONNECT": (False, "Camera connection")}        
+            return {"CONNECT": (False, "Camera connection")}
         info = {
             "CAMCON": (True, "Camera connection"),
             "CAMREADY": (self.camera.ImageReady, "Image ready"),
@@ -3901,7 +3903,9 @@ class Observatory:
     def cover_calibrator_az(self, value):
         logger.debug(f"Observatory.cover_calibrator_az = {value} called")
         self._cover_calibrator_az = (
-            min(max(float(value), 0), 360) if value is not None and value != "" else None
+            min(max(float(value), 0), 360)
+            if value is not None and value != ""
+            else None
         )
         self._config["cover_calibrator"]["cover_calibrator_az"] = (
             str(self._cover_calibrator_az)

--- a/pyscope/observatory/observatory.py
+++ b/pyscope/observatory/observatory.py
@@ -2416,18 +2416,7 @@ class Observatory:
         try:
             self.camera.Connected = True
         except:
-            return {"CONNECT": (False, "Camera connection")}
-        
-        # If ASCOM camera, EXPTIME and EXPOSURE should be obtained
-        # from camera.LastExposureDuration
-        if self._camera_driver == "ASCOMCamera":
-            try:
-                last_exposure_duration = self.camera.LastExposureDuration
-            except:
-                last_exposure_duration = self.camera.LastInputExposureDuration
-        else:
-            last_exposure_duration = None
-        
+            return {"CONNECT": (False, "Camera connection")}        
         info = {
             "CAMCON": (True, "Camera connection"),
             "CAMREADY": (self.camera.ImageReady, "Image ready"),
@@ -2442,8 +2431,9 @@ class Observatory:
             "JD": (None, "Julian date"),
             "MJD": (None, "Modified Julian date"),
             "MJD-OBS": (None, "Modified Julian date"),
-            "EXPTIME": (last_exposure_duration, "Exposure time [seconds]"),
-            "EXPOSURE": (last_exposure_duration, "Exposure time [seconds]"),
+            "CAMTIME": (None, "Exposure time from camera (T) or user (F)"),
+            "EXPTIME": (None, "Exposure time [seconds]"),
+            "EXPOSURE": (None, "Exposure time [seconds]"),
             "SUBEXP": (None, "Subexposure time [seconds]"),
             "XBINNING": (self.camera.BinX, "Image binning factor in width"),
             "YBINNING": (self.camera.BinY, "Image binning factor in height"),
@@ -2538,8 +2528,24 @@ class Observatory:
         except:
             pass
         try:
-            info["EXPTIME"] = (self.camera.ExposureTime, info["EXPTIME"][1])
-            info["EXPOSURE"] = (self.camera.ExposureTime, info["EXPOSURE"][1])
+            # If ASCOM camera, EXPTIME and EXPOSURE should be obtained
+            # from camera.LastExposureDuration (if that property exists or is not 0.0).
+            if self._camera_driver == "ASCOMCamera":
+                try:
+                    last_exposure_duration = self.camera.LastExposureDuration
+                    cam_time = True
+                    if last_exposure_duration == 0:
+                        last_exposure_duration = self.camera.LastInputExposureDuration
+                        cam_time = False
+                except:
+                    last_exposure_duration = self.camera.LastInputExposureDuration
+                    cam_time = False
+            else:
+                last_exposure_duration = None
+                cam_time = False
+            info["EXPTIME"] = (last_exposure_duration, info["EXPTIME"][1])
+            info["EXPOSURE"] = (last_exposure_duration, info["EXPOSURE"][1])
+            info["CAMTIME"] = (cam_time, info["CAMTIME"][1])
         except:
             pass
         try:

--- a/pyscope/observatory/observatory.py
+++ b/pyscope/observatory/observatory.py
@@ -794,7 +794,6 @@ class Observatory:
 
         self.telescope.Connected = True
         if self.telescope.Connected:
-            print("Telescope connected")
             logger.info("Telescope connected")
         else:
             logger.warning("Telescope failed to connect")
@@ -1228,8 +1227,6 @@ class Observatory:
         # By default, the ImageArray is 32 bit int, at least on my system
         # of a ZWO 290MM Mini - we need to convert it to 16 bit unsigned int
         img_array = np.array(self.camera.ImageArray).astype(np.uint16)
-        print(img_array.shape)
-        print(img_array.dtype)
         # Transpose the image array to match the FITS standard
         # as well as the axis order defined above
         img_array = np.transpose(img_array)

--- a/pyscope/observatory/observatory.py
+++ b/pyscope/observatory/observatory.py
@@ -1168,15 +1168,11 @@ class Observatory:
         if not self.camera.ImageReady:
             logger.exception("Image is not ready, cannot be saved")
             return False
-        
+
         # Read out the image array
         img_array = self.camera.ImageArray
 
-        if (
-            img_array is None
-            or len(img_array) == 0
-            or len(img_array) == 0
-        ):
+        if img_array is None or len(img_array) == 0 or len(img_array) == 0:
             logger.exception("Image array is empty, cannot be saved")
             return False
 


### PR DESCRIPTION
Solves #125 by implementing a working exposure time logging property in the ascom_camera.py script in my exptime branch and updating the observatory class to use this, which results in the last user-input exposure time being logged to the FITS header if the ASCOM LastExposureDuration function is not implemented in the ASCOM driver.

This builds off of #124 .