### PR TITLE
revert file parsing bug

### DIFF
--- a/pyscope/reduction/ccd_calib.py
+++ b/pyscope/reduction/ccd_calib.py
@@ -269,12 +269,8 @@ def ccd_calib_cli(
         logger.debug(f"Flat frame Y binning: {flat_ybin}")
         logger.debug(f"Flat pedestal: {flat_pedestal}")
 
-    if os.path.isdir(fnames):
-        fnames = Path(str(fnames) + "/*.fts")
-    fnames = glob.glob(str(fnames))
-    logger.debug(f"Found {len(fnames)} images")
-    logger.debug(f"images: {fnames}")
-
+    logger.debug(f"Calibrating {len(fnames)} image(s): {fnames}")
+    
     for fname in fnames:
         logger.info(f"Calibrating {fname}...")
         image, hdr = fits.getdata(fname).astype(np.float64), fits.getheader(fname)


### PR DESCRIPTION
the file arguments are parsed by the click library into a tuple, which is stored in fnames

Sorry to keep reverting this, but you said it was okay 🙂 per your comment: 

> If it still doesn't work, you can revert my changes to the file parsing, just lmk if you do. We need a standard file/directory parser function that has a uniform behavior across all our scripts.

The file/directory parsing and wildcard expansion are handled by the click library on [this line](https://github.com/albedozero/pyscope/blob/d84ed9ebefa412857b733a2e165ccbc0445cd58b/pyscope/reduction/ccd_calib.py#L81). Wildcard expansion happens before the script is called and click throws the [variadic arguments](https://click.palletsprojects.com/en/8.1.x/arguments/#variadic-arguments) into the tuple `fname`, so there's no need to glob - in fact it throws an exception because glob expects a string, not a tuple.